### PR TITLE
feat: add first gum command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,319 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "clap"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "dev-cli"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "which",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "libc"
+version = "0.2.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "which"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.20", features = ["derive"] }
+which = "7.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 which = "7.0.0"
+
+[[bin]]
+name = "dev-cli"
+path = "src/main.rs"

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
 .PHONY: help check fmt lint all dev clean
 
-help:
+help:		## help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-fmt:	## format code
+ci:			## run linters
 	cargo fmt
-
-lint:	## lint code
-	cargo clippy
-
-check:	## check for errors
 	cargo check
+	cargo clippy -- -D warnings
 
-ci: fmt lint check	## run commit ci checks
-
-dev:	## build and run project
+dev:		## build and run project
 	cargo run
 
-clean:	## clean project
+clean:		## clean project
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ ci:			## run linters
 dev:		## build and run project
 	cargo run
 
+install:	## install project
+	cargo install --path .
+
 clean:		## clean project
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # dev-cli
 
 cli for automating my dev workflows. built in pure rust.
+
+## pre-requisites:
+
+- [rust](https://www.rust-lang.org/tools/install)
+- [gum](https://github.com/charmbracelet/gum)
+
+## getting started:
+
+### run ci tools:
+
+```shell
+make ci
+```
+
+### test changes:
+
+```shell
+make dev
+```
+
+### install as binary:
+
+```shell
+make install
+```
+
+### clean up:
+
+```shell
+make clean
+```

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ cli for automating my dev workflows. built in pure rust.
 
 ## getting started:
 
-### run ci tools:
+### development:
 
 ```shell
+# run linters
 make ci
-```
 
-### test changes:
-
-```shell
+# test changes
 make dev
+
+# clean up
+make clean
 ```
 
 ### install as binary:
@@ -27,8 +28,8 @@ make dev
 make install
 ```
 
-### clean up:
+## usage
 
 ```shell
-make clean
+dev-cli
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,16 +19,21 @@ fn gum_command() -> Result<(), Box<dyn std::error::Error>> {
     // check if gun exists, if not: panic!
     which("gum").expect("gum not found. Please install gum first.");
 
+    // spawn new process, required due to tty interaction
     let gum_proc = Command::new("gum")
         .args(["choose", "apple", "banana", "cherry"])
         .stdout(Stdio::piped())
         .spawn()?;
 
+    // wait for process to finish and get output
     let gum_output = gum_proc.wait_with_output()?;
+
+    // parse output
     let gum_choice = String::from_utf8_lossy(&gum_output.stdout)
         .trim()
         .to_string();
     println!("selected choice: {}", gum_choice);
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,21 @@
+use clap::{CommandFactory, Parser, Subcommand};
 use std::process::{Command, Stdio};
-
 use which::which;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Parser)]
+#[command(author, version, about = "cli for automating dev workflows")]
+struct Cli {
+    #[clap(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    #[command(about = "choose a gum flavor")]
+    Gum {},
+}
+
+fn gum_command() -> Result<(), Box<dyn std::error::Error>> {
     // check if gun exists, if not: panic!
     which("gum").expect("gum not found. Please install gum first.");
 
@@ -16,6 +29,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .trim()
         .to_string();
     println!("selected choice: {}", gum_choice);
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::Gum {}) => gum_command()?,
+        None => {
+            let _ = Cli::command().print_help();
+            std::process::exit(0);
+        }
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,21 @@
-fn main() {
-    println!("Hello, world!");
+use std::process::{Command, Stdio};
+
+use which::which;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // check if gun exists, if not: panic!
+    which("gum").expect("gum not found. Please install gum first.");
+
+    let gum_proc = Command::new("gum")
+        .args(["choose", "apple", "banana", "cherry"])
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    let gum_output = gum_proc.wait_with_output()?;
+    let gum_choice = String::from_utf8_lossy(&gum_output.stdout)
+        .trim()
+        .to_string();
+    println!("selected choice: {}", gum_choice);
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ enum Commands {
 }
 
 fn gum_command() -> Result<(), Box<dyn std::error::Error>> {
-    // check if gun exists, if not: panic!
+    // check if gum exists, if not: panic!
     which("gum").expect("gum not found. Please install gum first.");
 
     // spawn new process, required due to tty interaction


### PR DESCRIPTION
## description

PR adds the first gum command which can be executed via `dev-cli` binary executable.

### claude notes

**milestones:**

- created basic dev-cli binary
- implemented gum choose command
- setup clap for command parsing
- proper help menu structure

**concepts learned:**

- Command for process execution
- clap cli basics
- derive attributes
- error handling

### changelog

- ➕ added `which` and `clap` dependencies
- ✨ added clap cli parser to `main.rs`
- ✨ added first gum command, executed with `std::process::Command`
- 📝 updated readme