### PR TITLE
ref: organize commands into modules with trait pattern

### DIFF
--- a/src/commands/manage.rs
+++ b/src/commands/manage.rs
@@ -1,7 +1,27 @@
+use clap::Subcommand;
 use std::fs;
 use which::which;
 
-use crate::{constants::BINARY_NAME, CliError, CliResult};
+use crate::{constants::BINARY_NAME, CliError, CliResult, Command};
+
+// define subcommands for 'manage' command
+#[derive(Subcommand)]
+pub enum ManageCommands {
+    #[command(about = "print location of devx binary")]
+    Where {},
+    #[command(about = "uninstall devx")]
+    Uninstall {},
+}
+
+// map manage subcommands to functions
+impl Command for ManageCommands {
+    fn execute(&self) -> CliResult<()> {
+        match self {
+            ManageCommands::Where {} => whereis(),
+            ManageCommands::Uninstall {} => uninstall(),
+        }
+    }
+}
 
 // uninstalls devx binary
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use error::{CliError, CliResult};
 pub use commands::choose::choose;
 pub use commands::manage::{uninstall, whereis, ManageCommands};
 
+// trait for all commands
 pub trait Command {
     fn execute(&self) -> CliResult<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,8 @@ pub use error::{CliError, CliResult};
 
 // re-export for external use
 pub use commands::choose::choose;
-pub use commands::manage::{uninstall, whereis};
+pub use commands::manage::{uninstall, whereis, ManageCommands};
+
+pub trait Command {
+    fn execute(&self) -> CliResult<()>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{CommandFactory, Parser, Subcommand};
-use devx::{choose, uninstall, whereis, CliResult};
+use devx::{choose, CliResult, Command, ManageCommands};
 
 #[derive(Parser)]
 #[command(author, version, about = "cli for automating dev workflows")]
@@ -19,15 +19,7 @@ enum Commands {
     },
 }
 
-#[derive(Subcommand)]
-enum ManageCommands {
-    #[command(about = "print location of devx binary")]
-    Where {},
-    #[command(about = "uninstall devx")]
-    Uninstall {},
-}
-
-fn invalid_subcommand(subcommand: &str) -> ! {
+fn handle_invalid_subcommand(subcommand: &str) -> ! {
     let mut cmd = Cli::command();
 
     // build is required to print help of subcommands.
@@ -43,11 +35,9 @@ fn main() -> CliResult<()> {
 
     match cli.command {
         Some(Commands::Choose {}) => choose()?,
-        Some(Commands::Manage { command }) => match command {
-            Some(ManageCommands::Where {}) => whereis()?,
-            Some(ManageCommands::Uninstall {}) => uninstall()?,
-            None => invalid_subcommand("manage"),
-        },
+        Some(Commands::Manage { command }) => {
+            command.map_or_else(|| handle_invalid_subcommand("manage"), |cmd| cmd.execute())?
+        }
         None => {
             let _ = Cli::command().print_help();
             std::process::exit(0);


### PR DESCRIPTION
## description:
refactored cli command handling using command trait pattern. moved command-specific logic into respective modules for better organization and maintainability.

### milestones:

- introduced command trait with execute method
- moved clap structs/enums to command modules
- implemented command trait for manage commands
- simplified main.rs match logic

### concepts learned:

- rust traits and `impl` blocks
- command pattern in rust
- module organization
- functional error handling with `map_or_else`

### changelog:

- ♻️ refactored command handling with new trait pattern
- 🏗️ restructured commands into modules
- 🔄 updated imports and exports
- 📝 updated command execution logic in main.rs