### PR TITLE
feat: remove confirm step in git switch command

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -168,40 +168,28 @@ pub fn switch_branch() -> CliResult<()> {
 
     let new_branch = Select::new("select new branch:", other_branches).prompt()?;
 
-    let confirm = Confirm::new("are you sure?")
-        .with_default(false)
-        .with_help_message("This data is stored for good reasons")
-        .prompt();
-
-    match confirm {
-        Ok(true) => {
-            println!("{}", "checking local branch status".bold());
-            let mut local_changes_stashed = false;
-            let git_status =
-                git_exec(&["status", "--porcelain"], "failed to get git status", true)?;
-            if !git_status.stdout.is_empty() {
-                println!("- local changes found. stashing local changes");
-                git_exec(&["add", "."], "failed to stage local changes", false)?;
-                git_exec(&["stash"], "failed to stash local changes", false)?;
-                local_changes_stashed = true;
-            }
-
-            git_exec(&["checkout", new_branch], "failed to switch branch", false)?;
-
-            if local_changes_stashed {
-                println!("{}", "restoring stashed changes".bold());
-                git_exec(&["stash", "pop"], "failed to restore local changes", false)?;
-                git_exec(&["stash", "clear"], "failed to clear stash", false)?;
-
-                println!("{}", "unstaging local changes.".bold());
-                git_exec(&["reset"], "failed to unstage local changes", false)?;
-            }
-
-            println!("{}", "branch switch complete ^.^".bold());
-        }
-        Ok(false) => println!("{}", "aborting branch switch".bold()),
-        Err(_) => println!("{}", "invalid input. aborting branch switch".bold()),
+    println!("{}", "checking local branch status".bold());
+    let mut local_changes_stashed = false;
+    let git_status = git_exec(&["status", "--porcelain"], "failed to get git status", true)?;
+    if !git_status.stdout.is_empty() {
+        println!("- local changes found. stashing local changes");
+        git_exec(&["add", "."], "failed to stage local changes", false)?;
+        git_exec(&["stash"], "failed to stash local changes", false)?;
+        local_changes_stashed = true;
     }
+
+    git_exec(&["checkout", new_branch], "failed to switch branch", false)?;
+
+    if local_changes_stashed {
+        println!("{}", "restoring stashed changes".bold());
+        git_exec(&["stash", "pop"], "failed to restore local changes", false)?;
+        git_exec(&["stash", "clear"], "failed to clear stash", false)?;
+
+        println!("{}", "unstaging local changes.".bold());
+        git_exec(&["reset"], "failed to unstage local changes", false)?;
+    }
+
+    println!("{}", "branch switch complete ^.^".bold());
 
     Ok(())
 }


### PR DESCRIPTION
removes confirm step from `git switch` command. not required.